### PR TITLE
Implement Serialize, Deserialize on "type" structs generated from ESDL files

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -102,7 +102,7 @@ impl Compiler {
 
     fn compile_schema_types(code: &mut String, types: &HashMap<String, CustomType>) {
         for (type_name, ty) in types {
-            writeln!(code, "#[derive(Clone, Debug, PartialEq)]");
+            writeln!(code, "#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]");
             writeln!(code, "pub struct {} {{", type_name);
             for (field_name, field) in &ty.fields {
                 writeln!(code, "    pub {}: {},", field_name, field.to_rust_type());


### PR DESCRIPTION
Currently referencing ESDL "types" from ESDL "events" will lead to a build error as the underlying "types" do not implement Serialize/Deserialize  and will break the trait derivation for the "event" in question. Example ESDL from  my [test app](https://github.com/Shearerbeard/event-sourcing-pizza-delivery-demo-rs/tree/type-missing-serialize-breaks-event) lincluded:

```
aggregate Order {
    order_placed(order_type: String!, line_items: [LineItem!]!, address: Address): OrderPlaced!
    order_status_changed(id: String!, order_status: String!): OrderStatusChanged!
}

event OrderPlaced {
    id: String!
    line_items: [LineItem!]!
    order_type: String!
    order_status: String!
    address: Address
}

event OrderStatusChanged {
    id: String!
    order_status: String!
}

type LineItem {
    item_id: String!
    quantity: Int!
    notes: String
}

type Address {
    address_1: String!
    address_2: String
    city: String!
    state: String!
    zip: String!
}
```

In this scenario the compiler will puke on the following:

```
     pub address: std::option::Option<Address>,
     |     ^^^ the trait `Deserialize<'_>` is not implemented for `Address`
     pub line_items: std::vec::Vec<LineItem>,
     |     ^^^ the trait `Deserialize<'_>` is not implemented for `LineItem`
     pub address: std::option::Option<Address>,
     |     ^^^ the trait `Serialize` is not implemented for `Address`
     pub line_items: std::vec::Vec<LineItem>,
     |     ^^^ the trait `Serialize` is not implemented for `LineItem`
     
```