### PR TITLE
Use `?` for optional types and implicitly require types

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,29 +23,29 @@ Additional languages may be added in the future. Contributions are welcome!
 
 ```
 aggregate BankAccount {
-  open_account(initial_balance: Float!) -> OpenedAccount!
-  deposit_funds(amount: Float!) -> ReceivedFunds!
-  withdraw_funds(amount: Float!) -> SentFunds!
-  send_funds(amount: Float!, user: User!) -> (SentFunds | ReceivedFunds)
+  open_account(initial_balance: Float) -> OpenedAccount
+  deposit_funds(amount: Float) -> ReceivedFunds
+  withdraw_funds(amount: Float) -> SentFunds
+  send_funds(amount: Float, user: User) -> (SentFunds? | ReceivedFunds?)
 }
 
 event OpenedAccount {
-  initial_balance: Float!
+  initial_balance: Float
 }
 
 event SentFunds {
-  amount: Float!
-  user: User
+  amount: Float
+  user: User?
 }
 
 event ReceivedFunds {
-  amount: Float!
-  user: User
+  amount: Float
+  user: User?
 }
 
 type User {
-  id: String!
-  name: String
+  id: String
+  name: String?
 }
 ```
 
@@ -61,12 +61,12 @@ type User {
 
 ### Optional & Required
 
-Types can be marked as required by adding the `!` suffix.
+Types can be marked as optional by adding the `?` suffix.
 
 | Type     | Syntax | Example   |
 | -------- | ------ | --------- |
-| Optional | `T`    | `String`  |
-| Required | `T!`   | `String!` |
+| Required | `T`    | `String`  |
+| Optional | `T?`   | `String?` |
 
 ### Repeating Types
 
@@ -77,14 +77,14 @@ Types can be repeated by wrapping them in `[]`.
 | Single | `T`    | `String`   |
 | Array  | `[T]`  | `[String]` |
 
-Remember, we can mark types as required, even in arrays.
+Remember, we can mark types as optional, even in arrays.
 
 | Type                 | Syntax  | Example      |
 | -------------------- | ------- | ------------ |
-| Optional Array       | `[T]`   | `[String]`   |
-| Required Array       | `[T]!`  | `[String]!`  |
-| Required Array Items | `[T!]`  | `[String!]`  |
-| Required Array Items | `[T!]!` | `[String!]!` |
+| Optional Array       | `[T?]?` | `[String?]?` |
+| Required Array       | `[T?]`  | `[String?]`  |
+| Required Array Items | `[T]?`  | `[String]?`  |
+| Required Array Items | `[T]`   | `[String]`   |
 
 ---
 

--- a/examples/bank-account-wasm/bank-account.esdl
+++ b/examples/bank-account-wasm/bank-account.esdl
@@ -1,17 +1,17 @@
 aggregate BankAccount {
-  open_account(initial_balance: Float!) -> OpenedAccount!
-  deposit_funds(amount: Float!) -> DepositedFunds!
-  withdraw_funds(amount: Float!) -> WithdrewFunds!
+  open_account(initial_balance: Float) -> OpenedAccount
+  deposit_funds(amount: Float) -> DepositedFunds
+  withdraw_funds(amount: Float) -> WithdrewFunds
 }
 
 event OpenedAccount {
-  initial_balance: Float!
+  initial_balance: Float
 }
 
 event DepositedFunds {
-  amount: Float!
+  amount: Float
 }
 
 event WithdrewFunds {
-  amount: Float!
+  amount: Float
 }

--- a/src/parser/aggregate.rs
+++ b/src/parser/aggregate.rs
@@ -118,11 +118,11 @@ pub enum ReturnTypeOptionalOrRequired<'i> {
 pub fn parse_return_type_optional_or_required(
     input: Span,
 ) -> IResult<Span, ReturnTypeOptionalOrRequired<'_>> {
-    map(pair(parse_camel_ident, opt(char('!'))), |(ty, required)| {
-        if required.is_some() {
-            ReturnTypeOptionalOrRequired::Required(ty)
-        } else {
+    map(pair(parse_camel_ident, opt(char('?'))), |(ty, optional)| {
+        if optional.is_some() {
             ReturnTypeOptionalOrRequired::Optional(ty)
+        } else {
+            ReturnTypeOptionalOrRequired::Required(ty)
         }
     })(input)
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -18,3 +18,178 @@ use self::schema::Schema;
 pub fn parse<'i>(input: impl Into<Span<'i>>) -> Result<Schema<'i>, Error<Span<'i>>> {
     final_parser(parse_schema)(input.into())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        aggregate::{Aggregate, Command, Param, ReturnType, ReturnTypeOptionalOrRequired},
+        event::{Event, Field},
+        parse,
+        schema::Schema,
+        types::{OptionalOrRequiredType, Scalar, ScalarOrUserType, Type},
+        Error, Span,
+    };
+
+    #[test]
+    fn it_parses_basic_schema() -> Result<(), Error<Span<'static>>> {
+        let schema_str = r#"
+            aggregate Hello {
+                world(name: String) -> FooEvent
+            }
+
+            event FooEvent {
+                name: String
+            }
+        "#;
+
+        let expected = Schema {
+            aggregates: vec![Aggregate {
+                ident: "Hello",
+                commands: vec![Command {
+                    ident: "world",
+                    params: vec![Param {
+                        ident: "name",
+                        ty: Type::Single(OptionalOrRequiredType::Required(
+                            ScalarOrUserType::Scalar(Scalar::String),
+                        )),
+                    }],
+                    return_type: ReturnType::Single(ReturnTypeOptionalOrRequired::Required(
+                        "FooEvent",
+                    )),
+                }],
+            }],
+            events: vec![Event {
+                ident: "FooEvent",
+                fields: vec![Field {
+                    ident: "name",
+                    ty: Type::Single(OptionalOrRequiredType::Required(ScalarOrUserType::Scalar(
+                        Scalar::String,
+                    ))),
+                }],
+            }],
+            types: vec![],
+        };
+
+        assert_eq!(parse(schema_str)?, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn it_parses_bank_account_schema() -> Result<(), Error<Span<'static>>> {
+        let schema_str = r#"
+          aggregate BankAccount {
+            open_account(name: String?, initial_balance: Float) -> OpenedAccount?
+            deposit_funds(amount: Float) -> DepositedFunds?
+            withdraw_funds(amount: Float) -> WithdrewFunds?
+          }
+          
+          event OpenedAccount {
+            name: String?
+            initial_balance: Float
+          }
+          
+          event DepositedFunds {
+            amount: Float
+          }
+          
+          event WithdrewFunds {
+            amount: Float
+          }          
+        "#;
+
+        let expected = Schema {
+            aggregates: vec![Aggregate {
+                ident: "BankAccount",
+                commands: vec![
+                    Command {
+                        ident: "open_account",
+                        params: vec![
+                            Param {
+                                ident: "name",
+                                ty: Type::Single(OptionalOrRequiredType::Optional(
+                                    ScalarOrUserType::Scalar(Scalar::String),
+                                )),
+                            },
+                            Param {
+                                ident: "initial_balance",
+                                ty: Type::Single(OptionalOrRequiredType::Required(
+                                    ScalarOrUserType::Scalar(Scalar::Float),
+                                )),
+                            },
+                        ],
+                        return_type: ReturnType::Single(ReturnTypeOptionalOrRequired::Optional(
+                            "OpenedAccount",
+                        )),
+                    },
+                    Command {
+                        ident: "deposit_funds",
+                        params: vec![Param {
+                            ident: "amount",
+                            ty: Type::Single(OptionalOrRequiredType::Required(
+                                ScalarOrUserType::Scalar(Scalar::Float),
+                            )),
+                        }],
+                        return_type: ReturnType::Single(ReturnTypeOptionalOrRequired::Optional(
+                            "DepositedFunds",
+                        )),
+                    },
+                    Command {
+                        ident: "withdraw_funds",
+                        params: vec![Param {
+                            ident: "amount",
+                            ty: Type::Single(OptionalOrRequiredType::Required(
+                                ScalarOrUserType::Scalar(Scalar::Float),
+                            )),
+                        }],
+                        return_type: ReturnType::Single(ReturnTypeOptionalOrRequired::Optional(
+                            "WithdrewFunds",
+                        )),
+                    },
+                ],
+            }],
+            events: vec![
+                Event {
+                    ident: "OpenedAccount",
+                    fields: vec![
+                        Field {
+                            ident: "name",
+                            ty: Type::Single(OptionalOrRequiredType::Optional(
+                                ScalarOrUserType::Scalar(Scalar::String),
+                            )),
+                        },
+                        Field {
+                            ident: "initial_balance",
+                            ty: Type::Single(OptionalOrRequiredType::Required(
+                                ScalarOrUserType::Scalar(Scalar::Float),
+                            )),
+                        },
+                    ],
+                },
+                Event {
+                    ident: "DepositedFunds",
+                    fields: vec![Field {
+                        ident: "amount",
+                        ty: Type::Single(OptionalOrRequiredType::Required(
+                            ScalarOrUserType::Scalar(Scalar::Float),
+                        )),
+                    }],
+                },
+                Event {
+                    ident: "WithdrewFunds",
+                    fields: vec![Field {
+                        ident: "amount",
+                        ty: Type::Single(OptionalOrRequiredType::Required(
+                            ScalarOrUserType::Scalar(Scalar::Float),
+                        )),
+                    }],
+                },
+            ],
+            types: vec![],
+        };
+
+        assert_eq!(parse(schema_str)?, expected);
+
+        Ok(())
+    }
+}

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -88,8 +88,8 @@ impl str::FromStr for Schema {
 ///
 /// ```text
 /// aggregate BankAccount  {
-///   open_account(user: User!, initial_balance: Float): OpenedAccount
-///   make_transaction(amount: Float): (DepositedFunds! | WithdrewFunds!)
+///   open_account(user: User, initial_balance: Float?): OpenedAccount
+///   make_transaction(amount: Float?): (DepositedFunds | WithdrewFunds)
 /// }
 /// ```
 #[derive(Clone, Debug, PartialEq, Serialize)]
@@ -127,8 +127,8 @@ impl Aggregate {
 }
 
 /// Command definition with name, params and resulting events.
-/// - `open_account(initial_balance: Float!): OpenedAccount`
-/// - `make_transaction(amount: Float!): (DepositedFunds | WithdrewFunds!)`
+/// - `open_account(initial_balance: Float): OpenedAccount?`
+/// - `make_transaction(amount: Float): (DepositedFunds? | WithdrewFunds)`
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct Command {
     pub name: String,
@@ -190,7 +190,7 @@ impl Param {
 
 /// Events resulted by a command.
 /// - `Event`
-/// - `(EventOne, EventTwo!)`
+/// - `(EventOne?, EventTwo)`
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub enum CommandEvents {
     Single(EventOpt),
@@ -255,7 +255,7 @@ impl EventOpt {
 ///
 /// ```text
 /// event WithdrewFunds {
-///   amount: Float!
+///   amount: Float
 /// }
 /// ```
 #[derive(Clone, Debug, PartialEq, Serialize)]
@@ -298,8 +298,8 @@ impl Event {
 ///
 /// ```text
 /// type User {
-///   name: String!
-///   age: Int
+///   name: String
+///   age: Int?
 /// }
 /// ```
 #[derive(Clone, Debug, PartialEq, Serialize)]
@@ -340,8 +340,8 @@ impl CustomType {
 
 /// A type which can be a single type or array type.
 /// - `String`
+/// - `[String]?`
 /// - `[String]`
-/// - `[String]!`
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub enum RepeatableType {
     Single(TypeOpt),
@@ -360,13 +360,13 @@ impl RepeatableType {
             )),
             crate::parser::types::Type::Array {
                 inner,
-                required: false,
+                optional: true,
             } => Ok(RepeatableType::OptionalArray(
                 TypeOpt::from_optional_or_required_type(custom_types, inner)?,
             )),
             crate::parser::types::Type::Array {
                 inner,
-                required: true,
+                optional: false,
             } => Ok(RepeatableType::RequiredArray(
                 TypeOpt::from_optional_or_required_type(custom_types, inner)?,
             )),
@@ -375,8 +375,8 @@ impl RepeatableType {
 }
 
 /// An optional or required type.
+/// - `String?`
 /// - `String`
-/// - `String!`
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub enum TypeOpt {
     Optional(TypeRef),


### PR DESCRIPTION
Removes the `!` syntax for required types and implicitly makes types required by default.
Types can be specified as optional by suffixing with `?`.