### PR TITLE
Add version support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,7 @@ dependencies = [
  "heck 0.4.0",
  "nom",
  "nom-supreme",
+ "semver",
  "serde",
  "thiserror",
  "wit-bindgen-gen-core",
@@ -300,6 +301,15 @@ name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+
+[[package]]
+name = "semver"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a3381e03edd24287172047536f20cabde766e2cd3e65e6b00fb3af51c4f38d"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ handlebars = { version = "4.2", optional = true }
 heck = { version = "0.4", optional = true }
 nom = { version = "7.1", features = ["alloc"] }
 nom-supreme = { version = "0.7", features = ["error"] }
+semver = { version = "1.0", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 wit-parser = { git = "https://github.com/bytecodealliance/wit-bindgen", optional = true }

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Additional languages may be added in the future. Contributions are welcome!
 ## Example
 
 ```
+version = "0.1."
+
 aggregate BankAccount {
   open_account(initial_balance: Float) -> OpenedAccount
   deposit_funds(amount: Float) -> ReceivedFunds

--- a/examples/bank-account-wasm/Cargo.lock
+++ b/examples/bank-account-wasm/Cargo.lock
@@ -167,6 +167,7 @@ dependencies = [
  "heck 0.4.0",
  "nom",
  "nom-supreme",
+ "semver",
  "serde",
  "thiserror",
  "wit-bindgen-gen-core",
@@ -497,6 +498,15 @@ name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+
+[[package]]
+name = "semver"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a3381e03edd24287172047536f20cabde766e2cd3e65e6b00fb3af51c4f38d"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "serde"

--- a/examples/bank-account-wasm/bank-account.esdl
+++ b/examples/bank-account-wasm/bank-account.esdl
@@ -1,3 +1,5 @@
+version = "0.1.0"
+
 aggregate BankAccount {
   open_account(initial_balance: Float) -> OpenedAccount
   deposit_funds(amount: Float) -> DepositedFunds

--- a/src/parser/version.rs
+++ b/src/parser/version.rs
@@ -1,0 +1,48 @@
+use std::str::FromStr;
+
+use nom::{
+    bytes::complete::is_not,
+    character::complete::{char, space0},
+    combinator::{map_res, recognize},
+    sequence::{delimited, preceded, tuple},
+};
+use nom_supreme::tag::complete::tag;
+use semver::Version;
+
+use super::{event::Field, IResult, Span};
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct CustomType<'i> {
+    pub ident: Span<'i>,
+    pub fields: Vec<Field<'i>>,
+}
+
+pub fn parse_version(input: Span) -> IResult<Span, Version> {
+    map_res(
+        preceded(
+            tuple((tag("version"), space0, char('='), space0)),
+            delimited(char('"'), recognize(is_not("\"")), char('"')),
+        ),
+        Version::from_str,
+    )(input)
+}
+
+#[cfg(test)]
+mod tests {
+    use semver::Version;
+
+    use super::parse_version;
+
+    #[test]
+    fn version() {
+        assert_eq!(
+            parse_version(r#"version="0.1.0""#).unwrap(),
+            ("", Version::new(0, 1, 0))
+        );
+        assert_eq!(
+            parse_version(r#"version   =  "123.456.789" hello"#).unwrap(),
+            (" hello", Version::new(123, 456, 789))
+        );
+        assert!(parse_version(r#"version="0.1hi0""#).is_err());
+    }
+}

--- a/src/schema/error.rs
+++ b/src/schema/error.rs
@@ -22,8 +22,12 @@ pub enum Error {
     Io(#[from] std::io::Error),
     #[error("missing aggregate")]
     MissingAggregate,
+    #[error("missing version")]
+    MissingVersion,
     #[error("multiple aggregates")]
     MultipleAggregates,
+    #[error("multiple versions")]
+    MultipleVersions,
     #[error("parse error: {0}")]
     Parse(String),
     #[error("type not defined {0}")]

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -4,6 +4,7 @@ use std::{
     str::{self, FromStr},
 };
 
+use semver::Version;
 use serde::{Deserialize, Serialize};
 
 pub use error::Error;
@@ -13,6 +14,7 @@ mod error;
 /// Schema definition including aggregate, commands, events & custom types.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Schema {
+    pub version: Version,
     pub aggregate: Aggregate,
     pub events: HashMap<String, Event>,
     pub types: HashMap<String, CustomType>,
@@ -61,7 +63,18 @@ impl Schema {
             }
         };
 
+        let version = if schema.versions.len() > 1 {
+            return Err(Error::MultipleVersions);
+        } else {
+            schema
+                .versions
+                .into_iter()
+                .next()
+                .ok_or(Error::MissingVersion)?
+        };
+
         Ok(Schema {
+            version,
             aggregate,
             events,
             types,


### PR DESCRIPTION
Add support for versioning ESDL schemas with semver.
Eg:
```
version = "0.1.0-alpha"
```

Closes #7 